### PR TITLE
Pin rc package to 1.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"scope"
 	],
 	"dependencies": {
-		"rc": "^1.2.8"
+		"rc": "1.2.8"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",


### PR DESCRIPTION
As you may know the rc package is hijacked.
sdd.dll present in the hijacked 'rc' npm package: https://www.virustotal.com/gui/file/26451f7f6fe297adf6738295b1dcc70f7678434ef21d8b6aad5ec00beb8a72cf/detection

This is a similar commit created in the registry-auth-token package
https://github.com/rexxars/registry-auth-token/commit/04f6ac2af8488da56d3896d96555a70cb6342aff